### PR TITLE
Update the respond function and rename slack.py to init.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -99,7 +99,7 @@ class ConnectorSlack(Connector):
                 message = Message(m["text"], user_info["name"], m["channel"], self)
                 await opsdroid.parse(message)
 
-    async def respond(self, message):
+    async def respond(self, message, room=None):
         """ Respond with a message """
         _LOGGER.debug("Responding with: '" + message.text +
                       "' in room " + message.room)


### PR DESCRIPTION
# Description

 The `respond` function in this connector needs to be updated since the optional argument `room` has been added to the base class Connector and Message. 

The `respond` function has been updated from:
`async def respond(self, message)`
to:
`async def respond(self, message, room=None)`

